### PR TITLE
最新のswiftlint に合わせて修正

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -4,12 +4,8 @@ disabled_rules: # rule identifiers to exclude from running
   - control_statement
 opt_in_rules: # some rules are only opt-in
   - empty_count
-  - missing_docs
   # Find all the available rules by running:
   # swiftlint rules
-included: # paths to include during linting. `--path` is ignored if present.
-  #- Source <- original
-  - SwiftConvert # Target Project Name
 excluded: # paths to ignore during linting. Takes precedence over `included`.
   - Carthage
   - Pods
@@ -25,7 +21,7 @@ force_try:
   severity: warning # explicitly
 # rules that have both warning and error levels, can set just the warning level
 # implicitly
-line_length: 110
+line_length: 200
 # they can set both implicitly with an array
 type_body_length:
   - 300 # warning
@@ -42,7 +38,7 @@ type_name:
     warning: 40
     error: 50
   excluded: iPhone # excluded via string
-variable_name:
+identifier_name:
   min_length: # only min_length
     error: 4 # only error
   excluded: # excluded via string array


### PR DESCRIPTION
- 最新のswiftlint に合わせて修正
- コメントは書きたくないのでmissing_docs は削除
- excludeルールがあるため included は不要なため削除
- line_length が自動生成コードとバッティングし過ぎで効率が悪いので削除
