### PR TITLE
shorten format

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,6 +12,8 @@ Style/NumericLiteralPrefix:
   Enabled: false
 Style/FormatString:
   EnforcedStyle: percent
+Style/FormatStringToken:
+  EnforcedStyle: unannotated
 Style/Documentation:
   Enabled: false
 Style/Lambda:


### PR DESCRIPTION
https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/FormatStringToken

実際にはformat => % 演算子 のため
mklint にて推奨されるスタイルは

```
'%02d' % 123
```